### PR TITLE
Add setup and build to paths that trigger actions

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -10,6 +10,8 @@ on:
       - lib/**
       - source/**
       - tests/**
+      - Makefile
+      - setup.py
   pull_request:
     branches: [ release ]
     paths:
@@ -19,6 +21,8 @@ on:
       - lib/**
       - source/**
       - tests/**
+      - Makefile
+      - setup.py
 
 jobs:
   build:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -10,6 +10,8 @@ on:
       - lib/**
       - source/**
       - tests/**
+      - Makefile
+      - setup.py
   pull_request:
     branches: [ master ]
     paths:
@@ -19,7 +21,8 @@ on:
       - lib/**
       - source/**
       - tests/**
-
+      - Makefile
+      - setup.py
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Make sure not to exlcude setup.py and Makefile from triggering a GHactions run.